### PR TITLE
docker compose added to image

### DIFF
--- a/src/main/insfrastructure/service/Dockerfile
+++ b/src/main/insfrastructure/service/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update -y && \
 	mv /opt/tools/ /opt/android-sdk/cmdline-tools/ && \
 	yes | /opt/android-sdk/cmdline-tools/tools/bin/sdkmanager --licenses && \
 	cd /opt/android-sdk/cmdline-tools/tools/bin/ && \
-	./sdkmanager "platforms;android-30" "platforms;android-31" "build-tools;30.0.2" "extras;google;m2repository"
+	./sdkmanager "platforms;android-30" "platforms;android-31" "platforms;android-33" "build-tools;30.0.2" "build-tools;33.0.1" "extras;google;m2repository"
 
 ENV ANDROID_HOME=/opt/android-sdk/
 

--- a/src/main/insfrastructure/service/Dockerfile
+++ b/src/main/insfrastructure/service/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
 		"deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
 	apt-get update -y && \
 	apt-get install -y docker-ce docker-ce-cli && \
+	apt-get install docker-compose-plugin && \
 	usermod -aG docker jenkins && \
 	systemctl enable docker && \
 	apt-get install -y jq cron gosu zip unzip jq git && \


### PR DESCRIPTION
Would be helpful if we have docker compose to use in our Jenkins. 
![image](https://user-images.githubusercontent.com/52011888/179157130-64f1dc98-4e4b-4639-b5e6-cd7b5c08d5ce.png)
